### PR TITLE
Fix ocean monument bounding boxes shifting on load

### DIFF
--- a/src/common/main/java/dev/worldgen/tectonic/Tectonic.java
+++ b/src/common/main/java/dev/worldgen/tectonic/Tectonic.java
@@ -25,6 +25,15 @@ public class Tectonic {
      */
     public static int BLENDING_VERSION = 1;
     public static String BLENDING_KEY = "tectonic:blending_version";
+    private static final ThreadLocal<Integer> MONUMENT_LOAD_OFFSET = new ThreadLocal<>();
+
+    public static void setMonumentLoadOffset(Integer offset) {
+        MONUMENT_LOAD_OFFSET.set(offset);
+    }
+
+    public static Integer getMonumentLoadOffset() {
+        return MONUMENT_LOAD_OFFSET.get();
+    }
 
     public static void init(Path folder) {
         ConfigHandler.load(folder.resolve("tectonic.json"));
@@ -38,6 +47,12 @@ public class Tectonic {
 
     @Expect
     public static int getBlendingVersion(CompoundTag tag);
+
+    @Expect
+    public static boolean isMonumentTag(CompoundTag tag);
+
+    @Expect
+    public static int computeMonumentOffset(CompoundTag tag);
 
     @Expect
     public static boolean canRunCommand(CommandSourceStack stack);

--- a/src/common/main/java/dev/worldgen/tectonic/mixin/StructurePieceMixin.java
+++ b/src/common/main/java/dev/worldgen/tectonic/mixin/StructurePieceMixin.java
@@ -1,5 +1,6 @@
 package dev.worldgen.tectonic.mixin;
 
+import dev.worldgen.tectonic.Tectonic;
 import dev.worldgen.tectonic.config.ConfigHandler;
 import net.minecraft.world.level.levelgen.structure.BoundingBox;
 import net.minecraft.world.level.levelgen.structure.StructurePiece;
@@ -10,7 +11,7 @@ import org.spongepowered.asm.mixin.injection.ModifyVariable;
 
 @Mixin(StructurePiece.class)
 public class StructurePieceMixin {
-    
+
     @ModifyVariable(
         method = "<init>(Lnet/minecraft/world/level/levelgen/structure/pieces/StructurePieceType;ILnet/minecraft/world/level/levelgen/structure/BoundingBox;)V",
         at = @At("HEAD"),
@@ -19,7 +20,11 @@ public class StructurePieceMixin {
     )
     private static BoundingBox tectonic$lowerOceanMonuments(BoundingBox boundingBox, StructurePieceType type) {
         if (type == StructurePieceType.OCEAN_MONUMENT_BUILDING && ConfigHandler.getState().general.modEnabled) {
-            return boundingBox.moved(0, ConfigHandler.getState().oceans.monumentOffset, 0);
+            Integer loadOffset = Tectonic.getMonumentLoadOffset();
+            int offset = loadOffset != null ? loadOffset : ConfigHandler.getState().oceans.monumentOffset;
+            if (offset != 0) {
+                return boundingBox.moved(0, offset, 0);
+            }
         }
         return boundingBox;
     }

--- a/src/common/main/java/dev/worldgen/tectonic/mixin/StructureStartMixin.java
+++ b/src/common/main/java/dev/worldgen/tectonic/mixin/StructureStartMixin.java
@@ -1,0 +1,27 @@
+package dev.worldgen.tectonic.mixin;
+
+import dev.worldgen.tectonic.Tectonic;
+import net.minecraft.nbt.CompoundTag;
+import net.minecraft.world.level.levelgen.structure.StructureStart;
+import net.minecraft.world.level.levelgen.structure.pieces.StructurePieceSerializationContext;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+@Mixin(StructureStart.class)
+public class StructureStartMixin {
+
+    @Inject(method = "loadStaticStart", at = @At("HEAD"))
+    private static void tectonic$loadStaticStartHead(StructurePieceSerializationContext context, CompoundTag tag, long seed, CallbackInfoReturnable<StructureStart> cir) {
+        Tectonic.setMonumentLoadOffset(null);
+        if (Tectonic.isMonumentTag(tag)) {
+            Tectonic.setMonumentLoadOffset(Tectonic.computeMonumentOffset(tag));
+        }
+    }
+
+    @Inject(method = "loadStaticStart", at = @At("RETURN"))
+    private static void tectonic$loadStaticStartReturn(StructurePieceSerializationContext context, CompoundTag tag, long seed, CallbackInfoReturnable<StructureStart> cir) {
+        Tectonic.setMonumentLoadOffset(null);
+    }
+}

--- a/src/common/main/tectonic.mixins.json
+++ b/src/common/main/tectonic.mixins.json
@@ -20,6 +20,7 @@
     "NoiseSettingsAccessor",
     "NoisesMixin",
     "StructurePieceMixin",
+    "StructureStartMixin",
     "TemperatureModifierMixin",
     "WorldCarverMixin"
   ]

--- a/src/shared/1.21.1/main/java/dev/worldgen/tectonic/TectonicActual.java
+++ b/src/shared/1.21.1/main/java/dev/worldgen/tectonic/TectonicActual.java
@@ -2,6 +2,7 @@ package dev.worldgen.tectonic;
 
 import net.minecraft.commands.CommandSourceStack;
 import net.minecraft.nbt.CompoundTag;
+import net.minecraft.nbt.ListTag;
 import net.minecraft.resources.Identifier;
 import net.msrandom.multiplatform.annotations.Actual;
 
@@ -22,7 +23,27 @@ public class TectonicActual {
     }
 
     @Actual
+    public static boolean isMonumentTag(CompoundTag tag) {
+        return "minecraft:monument".equals(tag.getString("id"));
+    }
+
+    @Actual
+    public static int computeMonumentOffset(CompoundTag tag) {
+        ListTag children = tag.getList("Children", ListTag.TAG_COMPOUND);
+        if (!children.isEmpty()) {
+            CompoundTag firstChild = children.getCompound(0);
+            int[] bb = firstChild.getIntArray("BB");
+            if (bb.length >= 2) {
+                // Vanilla monument building minY is 39; stored offset = storedMinY - 39
+                return bb[1] - 39;
+            }
+        }
+        return 0;
+    }
+
+    @Actual
     public static boolean canRunCommand(CommandSourceStack stack) {
         return stack.hasPermission(2);
     }
+
 }

--- a/src/shared/1.21.11/main/java/dev/worldgen/tectonic/TectonicActual.java
+++ b/src/shared/1.21.11/main/java/dev/worldgen/tectonic/TectonicActual.java
@@ -3,9 +3,9 @@ package dev.worldgen.tectonic;
 import net.minecraft.commands.CommandSourceStack;
 import net.minecraft.commands.Commands;
 import net.minecraft.nbt.CompoundTag;
+import net.minecraft.nbt.ListTag;
 import net.minecraft.resources.Identifier;
 import net.msrandom.multiplatform.annotations.Actual;
-import net.msrandom.multiplatform.annotations.Expect;
 
 public class TectonicActual {
     @Actual
@@ -24,7 +24,26 @@ public class TectonicActual {
     }
 
     @Actual
+    public static boolean isMonumentTag(CompoundTag tag) {
+        return "minecraft:monument".equals(tag.getStringOr("id", ""));
+    }
+
+    @Actual
+    public static int computeMonumentOffset(CompoundTag tag) {
+        ListTag children = tag.getListOrEmpty("Children");
+        if (!children.isEmpty() && children.get(0) instanceof CompoundTag firstChild) {
+            int[] bb = firstChild.getIntArray("BB").orElse(new int[0]);
+            if (bb.length >= 2) {
+                // Vanilla monument building minY is 39; stored offset = storedMinY - 39
+                return bb[1] - 39;
+            }
+        }
+        return 0;
+    }
+
+    @Actual
     public static boolean canRunCommand(CommandSourceStack stack) {
         return Commands.hasPermission(Commands.LEVEL_GAMEMASTERS).test(stack);
     }
+
 }

--- a/src/shared/1.21.11/main/java/dev/worldgen/tectonic/mixin/SerializableChunkDataMixin.java
+++ b/src/shared/1.21.11/main/java/dev/worldgen/tectonic/mixin/SerializableChunkDataMixin.java
@@ -1,7 +1,6 @@
 package dev.worldgen.tectonic.mixin;
 
 import dev.worldgen.tectonic.Tectonic;
-import net.minecraft.core.RegistryAccess;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.nbt.IntTag;
 import net.minecraft.nbt.ListTag;


### PR DESCRIPTION
Fixes #467 

Tested in 1.21.11.

If you add the Tectonic mod or change its offset setting, ocean monuments that already exist keep their original Y-level. Their bounding boxes do not move. Only newly generated monuments use the offset. 

Because of this, each monument’s bounding box always matches the structure’s actual blocks correctly.

How it works: Use the stored offset from NBT during deserialization instead of the current config value, preventing already-generated monuments from being re-shifted when the mod is added or the offset changes.