### PR TITLE
[FIX] Removes the non-existing `terralith:icy_spires` biome

### DIFF
--- a/src/common/main/resources/resourcepacks/tectonic/overlay.terratonic/data/minecraft/worldgen/noise_settings/overworld.json
+++ b/src/common/main/resources/resourcepacks/tectonic/overlay.terratonic/data/minecraft/worldgen/noise_settings/overworld.json
@@ -6083,8 +6083,7 @@
                             "type": "minecraft:biome",
                             "biome_is": [
                               "minecraft:ice_spikes",
-                              "terralith:snowy_cherry_grove",
-                              "terralith:icy_spires"
+                              "terralith:snowy_cherry_grove"
                             ]
                           },
                           "then_run": {


### PR DESCRIPTION
As reported here: 
- https://github.com/Stardust-Labs-MC/Terralith/issues/257
The `terralith:icy_spires` biome does not exist and causes world generation / server startup crashes on Minecraft 26.2

This pull request removes the single occurrence of this biome used.

closes #514 

**edit:** already got fixed after 3.0.26